### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![PyPI downloads](https://img.shields.io/pypi/dm/web-browser-mcp-server.svg)](https://pypi.org/project/web-browser-mcp-server/)
 > 🤖 Transform your AI applications with powerful web browsing capabilities! Let your AI read and understand the web.
 
+<a href="https://glama.ai/mcp/servers/3hphahzvql"><img width="380" height="200" src="https://glama.ai/mcp/servers/3hphahzvql/badge" alt="web-browser-mcp-server MCP server" /></a>
+
 ## ✨ Features
 
 - 🎯 **Smart Content Extraction** - Target exactly what you need with CSS selectors


### PR DESCRIPTION
This PR adds a badge for the [web-browser-mcp-server](https://glama.ai/mcp/servers/3hphahzvql) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/3hphahzvql"><img width="380" height="200" src="https://glama.ai/mcp/servers/3hphahzvql/badge" alt="web-browser-mcp-server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.